### PR TITLE
Ensure PyInstaller bundle finds config and extension files

### DIFF
--- a/dialer.py
+++ b/dialer.py
@@ -6,7 +6,17 @@ from urllib.parse import urlparse
 
 import requests
 
-CONFIG_FILE = Path(__file__).with_name('config.json')
+# helper to locate resource files both in source and frozen executable
+
+
+def get_resource_path(name: str) -> Path:
+    """Return the path to *name* next to the source file or executable."""
+    if getattr(sys, "frozen", False):
+        return Path(sys.executable).parent / name
+    return Path(__file__).with_name(name)
+
+
+CONFIG_FILE = get_resource_path("config.json")
 
 
 def load_config():
@@ -20,7 +30,7 @@ def load_config():
         return json.load(f)
 
 
-EXTENSION_FILE = Path(__file__).with_name("extension.txt")
+EXTENSION_FILE = get_resource_path("extension.txt")
 
 
 def load_extension() -> str:


### PR DESCRIPTION
## Summary
- Add `get_resource_path` helper to locate resources for both source and frozen executables
- Use `get_resource_path` to find `config.json` and `extension.txt`

## Testing
- `python -m pytest`
- `pyinstaller --onefile dialer.py`
- `./dist/dialer 12345`


------
https://chatgpt.com/codex/tasks/task_e_68b985e0bdb0832e923e67c087a21161