### PR TITLE
Update API endpoint in usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ This project provides a small command line dialer that triggers calls through th
 ```
 python dialer.py <phone_number>
 ```
-The script sends a request to `https://vpbx.me/api/originatecall/<origin>/<number>` using your API key and extension
-from `extension.txt`. The `<phone_number>` argument can be a plain number or a `tel:` link such as `tel:+123456789`.
+The script sends a request to `https://vpbx.me/api/c2cexternal/<extension>/<number>` using your API key and extension
+from `extension.txt`. The URL may include optional query parameters such as `timeout` and `outboundId` if those features
+are supported in the future. The `<phone_number>` argument can be a plain number or a `tel:` link such as `tel:+123456789`.
 
 ## Building a Windows executable
 The project can be bundled with [PyInstaller](https://www.pyinstaller.org/):


### PR DESCRIPTION
## Summary
- replace outdated `originatecall` endpoint with `c2cexternal`
- note potential `timeout` and `outboundId` query parameters for future support

## Testing
- `python -m py_compile dialer.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba8771317c832e84a71ed41b13869e