### PR TITLE
Switch dialer to c2cexternal endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ This project provides a small command line dialer that triggers calls through th
 ```
 python dialer.py <phone_number>
 ```
-The script sends a request to `https://vpbx.me/api/originatecall/<origin>/<number>` using your API key and extension
-from `extension.txt`. The `<phone_number>` argument can be a plain number or a `tel:` link such as `tel:+123456789`.
+The script sends a request to `https://vpbx.me/api/c2cexternal/<extension>/<number>` using your API key and
+extension from `extension.txt`. The `<phone_number>` argument can be a plain number or a `tel:` link such as
+`tel:+123456789`.
 
 ## Building a Windows executable
 The project can be bundled with [PyInstaller](https://www.pyinstaller.org/):

--- a/dialer.py
+++ b/dialer.py
@@ -42,8 +42,9 @@ def load_extension() -> str:
     return EXTENSION_FILE.read_text().strip()
 
 
-def make_call(api_key: str, origin: str, number: str) -> str:
-    url = f"https://vpbx.me/api/originatecall/{origin}/{number}"
+def make_call(api_key: str, extension: str, number: str) -> str:
+    """Initiate a click-to-call to *number* from *extension*."""
+    url = f"https://vpbx.me/api/c2cexternal/{extension}/{number}"
     headers = {
         "Content-Type": "application/json",
         "X-Api-Key": api_key,
@@ -70,12 +71,12 @@ def main(argv: list[str]) -> int:
         print("Config must contain 'api_key'.")
         return 1
     try:
-        origin = load_extension()
+        extension = load_extension()
     except FileNotFoundError:
         print("Missing extension.txt. Create it with your extension number.")
         return 1
     try:
-        result = make_call(api_key, origin, number)
+        result = make_call(api_key, extension, number)
         print("Call initiated:", result)
     except requests.HTTPError as exc:
         print("Failed to initiate call:", exc.response.text)


### PR DESCRIPTION
## Summary
- Update dialer to call `c2cexternal` API with extension then number
- Rename variables to clarify extension usage
- Document new endpoint in README

## Testing
- `python -m py_compile dialer.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba87704e08832eae38abf05ba0183f