### PR TITLE
Fix originatecall URL parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,8 @@ This project provides a small command line dialer that triggers calls through th
 ```
 python dialer.py <phone_number>
 ```
-The script sends a request to `https://vpbx.me/api/c2cexternal/<extension>/<number>` using your API key and extension
-from `extension.txt`. The URL may include optional query parameters such as `timeout` and `outboundId` if those features
-are supported in the future. The `<phone_number>` argument can be a plain number or a `tel:` link such as `tel:+123456789`.
+The script sends a request to `https://vpbx.me/api/originatecall/<phone_number>/<extension>` using your API key and extension
+from `extension.txt`. The `<phone_number>` argument can be a plain number or a `tel:` link such as `tel:+123456789`.
 
 ## Building a Windows executable
 The project can be bundled with [PyInstaller](https://www.pyinstaller.org/):

--- a/dialer.py
+++ b/dialer.py
@@ -43,8 +43,8 @@ def load_extension() -> str:
 
 
 def make_call(api_key: str, extension: str, number: str) -> str:
-    """Initiate a click-to-call to *number* from *extension*."""
-    url = f"https://vpbx.me/api/c2cexternal/{extension}/{number}"
+    """Initiate a click-to-call from *extension* to *number*."""
+    url = f"https://vpbx.me/api/originatecall/{number}/{extension}"
     headers = {
         "Content-Type": "application/json",
         "X-Api-Key": api_key,


### PR DESCRIPTION
## Summary
- use `originatecall` endpoint instead of `c2cexternal`
- send phone number before extension to correct origin/destination
- update README usage example

## Testing
- `python -m py_compile dialer.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba8ad34828832e8114365c9ace6f8d