### PR TITLE
Embed autoAnswer flag in originate call URL

### DIFF
--- a/dialer.py
+++ b/dialer.py
@@ -32,16 +32,15 @@ def load_config():
 
 def make_call(api_key: str, extension: str, number: str) -> str:
     """Initiate a click-to-call from *extension* to *number*."""
-    url = f"https://vpbx.me/api/originatecall/{extension}/{number}"
+    url = (
+        f"https://vpbx.me/api/originatecall/{extension}/{number}"
+        "?timeout=20&autoAnswer=true"
+    )
     headers = {
         "Content-Type": "application/json",
         "X-Api-Key": api_key,
     }
-    # Older documentation used the camelCase ``autoAnswer`` parameter, but the
-    # API expects a lowercase ``autoanswer`` flag for enabling automatic
-    # answering on compatible terminals.
-    params = {"timeout": 20, "autoanswer": "true"}
-    response = requests.get(url, headers=headers, params=params)
+    response = requests.get(url, headers=headers)
     response.raise_for_status()
     return response.text
 


### PR DESCRIPTION
## Summary
- pass autoAnswer query parameters directly in the originate call URL, removing separate params

## Testing
- `python -m py_compile dialer.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7fc42d568832ea969468014649d00